### PR TITLE
Variant pricing query fix for 1.3.0 release. Fixed minor warning in gemspec validation.

### DIFF
--- a/app/controllers/spree/admin/gift_cards_controller.rb
+++ b/app/controllers/spree/admin/gift_cards_controller.rb
@@ -23,8 +23,8 @@ module Spree
       private
 
       def find_gift_card_variants
-        gift_card_product_ids = Product.not_deleted.where(is_gift_card: true).pluck(:id)
-        @gift_card_variants = Variant.where(["price > 0 AND product_id IN (?)", gift_card_product_ids]).order("price")
+        gift_card_product_ids = Product.not_deleted.where(["is_gift_card = ?", true]).map(&:id)
+        @gift_card_variants = Variant.joins(:prices).where(["amount > 0 AND product_id IN (?)", gift_card_product_ids]).order("amount")
       end
 
     end

--- a/app/controllers/spree/gift_cards_controller.rb
+++ b/app/controllers/spree/gift_cards_controller.rb
@@ -38,7 +38,7 @@ module Spree
 
     def find_gift_card_variants
       gift_card_product_ids = Product.not_deleted.where(["is_gift_card = ?", true]).map(&:id)
-      @gift_card_variants = Variant.where(["price > 0 AND product_id IN (?)", gift_card_product_ids]).order("price")
+      @gift_card_variants = Variant.joins(:prices).where(["amount > 0 AND product_id IN (?)", gift_card_product_ids]).order("amount")
     end
 
   end

--- a/spree_gift_card.gemspec
+++ b/spree_gift_card.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |s|
   s.summary     = 'Spree Gift Card'
   s.description = 'Spree Gift Card Extension'
 
-  s.author      = ['Jeff Dutil']
+  s.authors     = ['Jeff Dutil']
   s.email       = ['jdutil@burlingtonwebapps.com']
   s.homepage    = 'http://github.com/jdutil/spree_gift_card'
 


### PR DESCRIPTION
It appears that the 1-3-stable branch doesn't work with the spree_core 1.3.0 gem. Here's a few minor patches to get it working.

Hopefully I'm not doing something stupid in my spree install where I'm not actually using 1.3.0. :-)
