### PR TITLE
Fix seed error if not tracking inventory

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,7 +6,9 @@ if Spree::Product.gift_cards.count == 0
   [25, 50, 75, 100].each do |value|
     option_value = Spree::OptionValue.new(name: value, presentation: "$#{value}")
     option_value.option_type = option_type
-    variant = Spree::Variant.new(price: value.to_i, sku: "GIFTCERT#{value}", on_hand: 1000)
+    opts = { price: value.to_i, sku: "GIFTCERT#{value}" }
+    opts.merge!({ on_hand: 1000 }) if Spree::Config[:track_inventory_levels]
+    variant = Spree::Variant.new(opts)
     variant.option_values << option_value
     product.variants << variant
   end


### PR DESCRIPTION
For stores that do not track inventory, the following error occurs when running rails g spree_gift_card:seed

```
app/models/spree/variant.rb:59:in `on_hand=': Cannot set on_hand value when Spree::Config[:track_inventory_levels] is false (RuntimeError)
```

Easy enough to work around (just removing the parameter from that line in the seed file), but thought I'd mention it.
