### PR TITLE
Use correct path helper to link to orders associated with card

### DIFF
--- a/app/views/spree/admin/gift_cards/edit.html.erb
+++ b/app/views/spree/admin/gift_cards/edit.html.erb
@@ -20,6 +20,6 @@
 <h2><%= Spree.t(:transactions) %><h2>
 <ul>
   <% @gift_card.transactions.each do |transaction| %>
-  <li><%= link_to "#{transaction.order.number}:" , admin_order_path(transaction.order) %> <%= number_to_currency transaction.amount %></li>
+  <li><%= link_to "#{transaction.order.number}:" , edit_admin_order_path(transaction.order) %> <%= number_to_currency transaction.amount %></li>
   <% end %>
 </ul>


### PR DESCRIPTION
Title line basically explains it all... I'm wondering why the using the path helper for an action that doesn't result in an error. Perhaps that route should be removed from spree core?

Also, this should probably be merged to master and 2-1-stable if you're happy with the PR.
