### PR TITLE
An SMTP From address is required to send a message.

### DIFF
--- a/app/mailers/spree/order_mailer_decorator.rb
+++ b/app/mailers/spree/order_mailer_decorator.rb
@@ -4,6 +4,6 @@ Spree::OrderMailer.class_eval do
     @order = order
     subject = "#{Spree::Config[:site_name]} Gift Card"
     @gift_card.update_attribute(:sent_at, Time.now)
-    mail(:to => card.email, :subject => subject)
+    mail(:to => card.email, :from => from_address, :subject => subject)
   end
 end


### PR DESCRIPTION
I got this message when actually sending the gift card email. Not sure, how this could have worked before.

ArgumentError: An SMTP From address is required to send a message. Set the message smtp_envelope_from, return_path, sender, or from address. 

Stacktrace:
/vendor/bundle/ruby/1.9.1/gems/mail-2.5.4/lib/mail/check_delivery_params.rb:5 in "check_delivery_params"
/vendor/bundle/ruby/1.9.1/gems/mail-2.5.4/lib/mail/network/delivery_methods/smtp.rb:98 in "deliver!"
/vendor/bundle/ruby/1.9.1/gems/mail-2.5.4/lib/mail/message.rb:2129 in "do_delivery"
/vendor/bundle/ruby/1.9.1/gems/mail-2.5.4/lib/mail/message.rb:232 in "block in deliver"
/vendor/bundle/ruby/1.9.1/gems/actionmailer-3.2.16/lib/action_mailer/base.rb:415 in "block in deliver_mail"
/vendor/bundle/ruby/1.9.1/gems/activesupport-3.2.16/lib/active_support/notifications.rb:123 in "block in instrument"
/vendor/bundle/ruby/1.9.1/gems/activesupport-3.2.16/lib/active_support/notifications/instrumenter.rb:20 in "instrument"
/vendor/bundle/ruby/1.9.1/gems/activesupport-3.2.16/lib/active_support/notifications.rb:123 in "instrument"
/vendor/bundle/ruby/1.9.1/gems/actionmailer-3.2.16/lib/action_mailer/base.rb:413 in "deliver_mail"
/vendor/bundle/ruby/1.9.1/gems/mail-2.5.4/lib/mail/message.rb:232 in "deliver"
/vendor/bundle/ruby/1.9.1/bundler/gems/spree_gift_card-95ca3e4414b6/app/models/spree/order_decorator.rb:18 in "block in finalize_with_gift_card!"
