### PR TITLE
Fix 2.2 installer incompatibility.

### DIFF
--- a/lib/generators/spree_gift_card/install_generator.rb
+++ b/lib/generators/spree_gift_card/install_generator.rb
@@ -3,13 +3,13 @@ module SpreeGiftCard
     class InstallGenerator < Rails::Generators::Base
 
       def add_javascripts
-        append_file "vendor/assets/javascripts/spree/frontend/all.js", "//= require store/spree_gift_card\n"
-        append_file "vendor/assets/javascripts/spree/backend/all.js", "//= require admin/spree_gift_card\n"
+        append_file "vendor/assets/javascripts/spree/frontend/all.js", "//= require spree/frontend/spree_gift_card\n"
+        append_file "vendor/assets/javascripts/spree/backend/all.js", "//= require spree/backend/spree_gift_card\n"
       end
 
       def add_stylesheets
-        inject_into_file "vendor/assets/stylesheets/spree/frontend/all.css", " *= require store/spree_gift_card\n", :before => /\*\//, :verbose => true
-        inject_into_file "vendor/assets/stylesheets/spree/backend/all.css", " *= require admin/spree_gift_card\n", :before => /\*\//, :verbose => true
+        inject_into_file "vendor/assets/stylesheets/spree/frontend/all.css", " *= require spree/frontend/spree_gift_card\n", :before => /\*\//, :verbose => true
+        inject_into_file "vendor/assets/stylesheets/spree/backend/all.css", " *= require spree/backend/spree_gift_card\n", :before => /\*\//, :verbose => true
       end
 
       def add_migrations


### PR DESCRIPTION
Spree stores now serve up application.css/js instead of splitting them in to
store and admin.
