### PR TITLE
Update spree_gift_card to work with Spree 2.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
-gem 'spree', github: 'spree/spree', branch: '2-2-stable'
+gem 'spree', github: 'spree/spree', branch: '2-4-stable'
 gemspec

--- a/app/controllers/spree/checkout_controller_decorator.rb
+++ b/app/controllers/spree/checkout_controller_decorator.rb
@@ -2,13 +2,13 @@ Spree::CheckoutController.class_eval do
 
   Spree::PermittedAttributes.checkout_attributes << :gift_code
 
-  durably_decorate :update, mode: 'soft', sha: '908d25b70eff597d32ddad7876cd89d3683d6734' do
+  durably_decorate :update, mode: 'soft', sha: '9774bcd294f748bd6185a0c8f7d518e624b99ff7' do
     if @order.update_from_params(params, permitted_checkout_attributes)
       if @order.gift_code.present?
         render :edit and return unless apply_gift_code
       end
 
-      persist_user_address
+      @order.temporary_address = !params[:save_user_address]
       unless @order.next
         flash[:error] = @order.errors.full_messages.join("\n")
         redirect_to checkout_state_path(@order.state) and return

--- a/app/models/spree/calculator/gift_card.rb
+++ b/app/models/spree/calculator/gift_card.rb
@@ -1,20 +1,16 @@
 require_dependency 'spree/calculator'
 
 module Spree
-  class Calculator < ActiveRecord::Base
-    class GiftCard < Calculator
+  class Calculator::GiftCard < Calculator
+    def self.description
+      Spree.t(:gift_card_calculator)
+    end
 
-      def self.description
-        Spree.t(:gift_card_calculator)
-      end
-
-      def compute(order, gift_card)
-        # Ensure a negative amount which does not exceed the sum of the order's item_total, ship_total, and 
-        # tax_total, minus other credits.
-        credits = order.adjustments.select{|a|a.amount < 0 && a.source_type != 'Spree::GiftCard'}.map(&:amount).sum
-        [(order.item_total + order.ship_total + order.additional_tax_total + credits), gift_card.current_value].min * -1
-      end
-
+    def compute(order, gift_card)
+      # Ensure a negative amount which does not exceed the sum of the order's item_total, ship_total, and
+      # tax_total, minus other credits.
+      credits = order.adjustments.select{|a|a.amount < 0 && a.source_type != 'Spree::GiftCard'}.map(&:amount).sum
+      [(order.item_total + order.ship_total + order.additional_tax_total + credits), gift_card.current_value].min * -1
     end
   end
 end

--- a/app/models/spree/gift_card.rb
+++ b/app/models/spree/gift_card.rb
@@ -20,7 +20,7 @@ module Spree
     before_validation :set_calculator, on: :create
     before_validation :set_values, on: :create
 
-    include Spree::Core::CalculatedAdjustments
+    include Spree::CalculatedAdjustments
 
     def apply(order)
       # Nothing to do if the gift card is already associated with the order

--- a/spree_gift_card.gemspec
+++ b/spree_gift_card.gemspec
@@ -17,10 +17,10 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
 
   s.add_dependency 'durable_decorator', '~> 0.2.0'
-  s.add_dependency 'spree_api',         '~> 2.2.0'
-  s.add_dependency 'spree_backend',     '~> 2.2.0'
-  s.add_dependency 'spree_core',        '~> 2.2.0'
-  s.add_dependency 'spree_frontend',    '~> 2.2.0'
+  s.add_dependency 'spree_api',         '~> 2.4.0'
+  s.add_dependency 'spree_backend',     '~> 2.4.0'
+  s.add_dependency 'spree_core',        '~> 2.4.0'
+  s.add_dependency 'spree_frontend',    '~> 2.4.0'
 
   s.add_development_dependency 'capybara', '~> 2.0'
   s.add_development_dependency 'coffee-rails'


### PR DESCRIPTION
I'm in the process of using your plugin as a base to develop some other gift card functionality for a client, and the first step is to make it compatible with Spree 2.4.

I'm afraid I don't have the bandwidth to support the entire library as this is a single project task (and will involve significantly modifying it from the generic base) but hopefully the changes are useful to others.